### PR TITLE
Support for platformio and esp32-idf

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,20 @@
+{
+  "name": "JPEGENC",
+  "version": "1.1.0",
+  "description": "Designed to provide a fast and fully functional JPEG encoder that can use minimal memory by encoding images an MCU at a time. Supports grayscale and color output with optional subsampling and 4 quality levels.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/bitbank2/JPEGENC"
+  },
+  "authors":
+  [
+    {
+      "name": "Larry Bank"
+    }
+  ],
+  "license": "Apache License 2.0",
+  "homepage": "https://github.com/bitbank2/JPEGENC",
+  "frameworks": "*",
+  "platforms": "*"
+}

--- a/src/JPEGENC.h
+++ b/src/JPEGENC.h
@@ -21,7 +21,7 @@
 //
 #ifndef __JPEGENC__
 #define __JPEGENC__
-#if defined( MICROPY_PY_SENSOR ) || defined( __MACH__ ) || defined( __LINUX__ ) || defined( __MCUXPRESSO )
+#if defined( MICROPY_PY_SENSOR ) || defined( __MACH__ ) || defined( __LINUX__ ) || defined( __MCUXPRESSO ) || defined( ESP_PLATFORM )
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>


### PR DESCRIPTION
This PR adds a *library.json* file and an ESP-IDF platform test, allowing the JPEGENC library to be used not only in Arduino-based projects but also in ESP-IDF environments, such as ESPHome. This improves compatibility and enables seamless integration with projects using PlatformIO and the ESP-IDF framework.